### PR TITLE
CORE-11135: PR check, must have a JIra refrence

### DIFF
--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -1,0 +1,14 @@
+name: 'Check PR Title'
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+
+jobs:
+  check-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: morrisoncole/pr-lint-action@v1.6.1
+        with:
+          title-regex: '^([A-Z]{2,}-\d+)(.*)'
+          on-failed-regex-comment: "PR title failed to match regex -> `%regex%`"
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -9,6 +9,6 @@ jobs:
     steps:
       - uses: morrisoncole/pr-lint-action@v1.6.1
         with:
-          title-regex: '^([A-Z]{2,}-\d+)(.*)'
+          title-regex: '^((CORDA|EG|ENT|INFRA|CORE)-\d+)(.*)'
           on-failed-regex-comment: "PR title failed to match regex -> `%regex%`"
           repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
For tracking and compliance reasons, all work should have an associated Jira going forward, no NOTICK titles.

this check will block merging unless a valid Jira is in the title