### PR TITLE
INFRA-2041: Remove nexusScan pipeline due to nexus license expiring

### DIFF
--- a/.ci/nightly/JenkinsfileNexusScan
+++ b/.ci/nightly/JenkinsfileNexusScan
@@ -1,5 +1,0 @@
-@Library('corda-shared-build-pipeline-steps@5.0') _
-
-cordaNexusScanPipeline(
-    nexusAppId: 'com.corda.CSDE-Java.5.0'
-)


### PR DESCRIPTION
Removed nexus dependency before license expires