### PR TITLE
ES-650: use latest version of shared lib

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.0') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 cordaPipeline(
     nexusAppId: 'com.corda.CSDE-Java.5.0',

--- a/.ci/nightly/JenkinsfileSnykScan
+++ b/.ci/nightly/JenkinsfileSnykScan
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.0') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 cordaSnykScanPipeline (
     snykTokenId: 'r3-snyk-corda5',

--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -9,6 +9,6 @@ jobs:
     steps:
       - uses: morrisoncole/pr-lint-action@v1.6.1
         with:
-          title-regex: '^((CORDA|EG|ENT|INFRA|CORE)-\d+)(.*)'
+          title-regex: '^((CORDA|EG|ENT|INFRA|CORE|ES)-\d+)(.*)'
           on-failed-regex-comment: "PR title failed to match regex -> `%regex%`"
           repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
- bump to 5.1, the latest version of shared lib, this change ensures Snyk nightly scans are running correctly, Logic in 5.0 branch is outdated.

- allow ES jiras

No other functional change 