### PR TITLE
CORE-15002: Suppress unchecked cast warning in contract test

### DIFF
--- a/contracts/src/test/java/com/r3/developers/csdetemplate/utxoexample/contracts/ChatContractUpdateCommandTest.java
+++ b/contracts/src/test/java/com/r3/developers/csdetemplate/utxoexample/contracts/ChatContractUpdateCommandTest.java
@@ -13,6 +13,7 @@ import static com.r3.developers.csdetemplate.utxoexample.contracts.ChatContract.
 
 public class ChatContractUpdateCommandTest extends ContractTest {
 
+    @SuppressWarnings("unchecked")
     private StateAndRef<ChatState> createInitialChatState() {
         ChatState outputChatState = new ChatContractCreateCommandTest().outputChatState;
         UtxoSignedTransaction transaction = getLedgerService()


### PR DESCRIPTION
The suggested fix is to simply suppress the warning. We're creating a ChatState so it will cast without issue.
The warning tries to steer you down the route of generics, which only moves the casting to later.
Unable to perform an "instanceOf" check due to StateAndRef being an interface and unable to be used as a type