### PR TITLE
CORE-16311: Updated Contract Testing version to 1.0.0-RC01

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -44,7 +44,7 @@ junitVersion = 5.8.2
 mockitoKotlinVersion=4.0.0
 mockitoVersion=4.6.1
 hamcrestVersion=2.2
-contractTestingVersion=0.9.1-beta-+
+contractTestingVersion=1.0.0-RC01
 
 # Specify the maximum amount of time allowed for the CPI upload
 # As your CorDapp grows you might need to increase this


### PR DESCRIPTION
Set the Contract Testing version to the release candidate artifacts version: 1.0.0-RC01