### PR TITLE
CORE-16818: Remove duplicated tasks being invoked

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,6 @@ allprojects {
     version '1.0-SNAPSHOT'
 
     // Configure the CSDE
-    apply plugin: 'net.corda.plugins.csde'
     csde {
         cordaClusterURL = "https://localhost:8888"
         networkConfigFile = "config/static-network-config.json"

--- a/workflows/build.gradle
+++ b/workflows/build.gradle
@@ -66,7 +66,7 @@ dependencies {
 }
 
 tasks.withType(Test).configureEach {
-    dependsOn('getNotaryServerCPB')
+    dependsOn(':getNotaryServerCPB')
     doFirst {
         jvmArgs '--add-opens', 'java.base/java.lang=ALL-UNNAMED',
                 '--add-opens', 'java.base/java.lang.invoke=ALL-UNNAMED',


### PR DESCRIPTION
So "apply" wasn't the correct thing to do. As the CSDE config is being defined in the all projects block, apply was duplicating that task registration onto the contracts & workflows submodules. This resulted in a given task being invoked 3 times.
Found that we can depend on the root task by including the colon, which acts like a path, so this now reads as workflows tests depdends on the root task "getNotaryServerCPB"

Evidence of task only being invoked once:
<img width="1518" alt="Screenshot 2023-08-31 at 14 32 38" src="https://github.com/corda/CSDE-cordapp-template-java/assets/92731849/739450de-eb66-4f98-be3b-528722dc5bd9">

Regpack run https://ci02.dev.r3.com/job/QA/job/Craft_Tests/job/qa-regpack-csde/job/main/408
